### PR TITLE
[#94939334] Redis VM is now deprecated as of version 2.4

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -359,7 +359,7 @@ slowlog-max-len 1024
 # To enable VM just set 'vm-enabled' to yes, and set the following three
 # VM parameters accordingly to your needs.
 
-vm-enabled no
+# vm-enabled no
 # vm-enabled yes
 
 # This is the path of the Redis swap file. As you can guess, swap files
@@ -373,7 +373,7 @@ vm-enabled no
 # *** WARNING *** if you are using a shared hosting the default of putting
 # the swap file under /tmp is not secure. Create a dir with access granted
 # only to Redis user and configure Redis to create the swap file there.
-vm-swap-file /tmp/redis.swap
+# vm-swap-file /tmp/redis.swap
 
 # vm-max-memory configures the VM to use at max the specified amount of
 # RAM. Everything that deos not fit will be swapped on disk *if* possible, that
@@ -383,7 +383,7 @@ vm-swap-file /tmp/redis.swap
 # default, just specify the max amount of RAM you can in bytes, but it's
 # better to leave some margin. For instance specify an amount of RAM
 # that's more or less between 60 and 80% of your free RAM.
-vm-max-memory 0
+# vm-max-memory 0
 
 # Redis swap files is split into pages. An object can be saved using multiple
 # contiguous pages, but pages can't be shared between different objects.
@@ -394,7 +394,7 @@ vm-max-memory 0
 # If you use a lot of small objects, use a page size of 64 or 32 bytes.
 # If you use a lot of big objects, use a bigger page size.
 # If unsure, use the default :)
-vm-page-size 32
+# vm-page-size 32
 
 # Number of total memory pages in the swap file.
 # Given that the page table (a bitmap of free/used pages) is taken in memory,
@@ -407,7 +407,7 @@ vm-page-size 32
 #
 # It's better to use the smallest acceptable value for your application,
 # but the default is large in order to work in most conditions.
-vm-pages 134217728
+# vm-pages 134217728
 
 # Max number of VM I/O threads running at the same time.
 # This threads are used to read/write data from/to swap file, since they
@@ -418,7 +418,7 @@ vm-pages 134217728
 #
 # The special value of 0 turn off threaded I/O and enables the blocking
 # Virtual Memory implementation.
-vm-max-threads 4
+# vm-max-threads 4
 
 ############################### ADVANCED CONFIG ###############################
 


### PR DESCRIPTION
[Manage all Ansible dependencies from Ansible Galaxy](https://www.pivotaltracker.com/story/show/94939334)

**What**

Redis VM is now deprecated. Redis 2.4 was the last Redis version
featuring Virtual Memory (but it also warns you that Virtual Memory
usage is discouraged).

At this time 2.6 is considered to be very old and the guidance from
[redis](http://redis.io/download) is that you should not use Redis 2.6
