### PR TITLE
[#97381908] Redis runs out of connections with the default settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,6 @@ redis_db_dir: /var/lib/redis
 redis_role: master
 redis_requirepass: false
 redis_pass: None
-redis_max_clients: 128
 redis_max_memory: 512mb
 redis_maxmemory_policy: volatile-lru
 redis_appendfsync: everysec

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -178,7 +178,9 @@ requirepass {{ redis_pass }}
 # Once the limit is reached Redis will close all the new connections sending
 # an error 'max number of clients reached'.
 #
+{% if redis_max_clients is defined %}
 maxclients {{ redis_max_clients }}
+{% endif %}
 
 # Don't use more memory than the specified amount of bytes.
 # When the memory limit is reached Redis will try to remove keys


### PR DESCRIPTION
[Redis runs out of connections with the default settings:  ERR max number of clients reached](https://www.pivotaltracker.com/story/show/97381908)

**What**

Our redis installation currently have a maximum of 128 connections. The tsuru api creates lots of connections and sometimes the platform fails with: `ERR max number of clients reached`

After investigating `Tsuru API service` and the `Redis` configuration we found that we have a extremely low setting for [maxclients](http://redis.io/topics/clients) i.e we have `128` while `Redis 2.6's` default it `10,000`.

Redis can also dynamically set the number of `maxclient` connections based on the current operating systems limit.

**How this PR should be review**

This PR should be review in the following context:
- I want to modify the configuration of `Redis` so I can use dynamic `maxclients`
- I want to change the default behaviour of the playbook so it will configure redis based on the capabilities of the machine it is installed on versus an abitrary setting of 128 `maxclients`.

**Who should review this PR**
- Anyone on the team with the exception of @mketel who I paired with.

**How to test**
- Checkout this playbook into your roles directory and use the [tsuru-ansible](https://github.com/alphagov/tsuru-ansible) Makefile to walk through the steps excluding the steps where you:
  - remove the `roles` directory and,
  - install playbooks.

**Notes**
- Once this PR is merged a new release has to be created (`e.g. v0.0.2`) and the `requirements.yml` updated in [tsuru-ansible](https://github.com/alphagov/tsuru-ansible) 
