### PR TITLE
[#98748824] Pin redis version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Role Variables
 The variables that can be passed to this role and a brief description about
 them are as follows. See the documentation for Redis for details:
 
+  redis_server_version: 2.6.0       # The version of redis to install defaults to `latest`
 	redis_bind_address                # The network address for redis to bind to 
         redis_port: 6379                  # Port for redis server
 	redis_syslog_enabled: "yes"       # enable_syslog

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Role Variables
 The variables that can be passed to this role and a brief description about
 them are as follows. See the documentation for Redis for details:
 
-  redis_server_version: 2.6.0       # The version of redis to install defaults to `latest`
-	redis_bind_address                # The network address for redis to bind to 
-        redis_port: 6379                  # Port for redis server
+	redis_server_version: 2.6.0       # The version of redis to install defaults to `latest`
+	redis_bind_address                # The network address for redis to bind to
+	redis_port: 6379                  # Port for redis server
 	redis_syslog_enabled: "yes"       # enable_syslog
 	redis_databases: 16               # Set number of databases
 	redis_database_save_times:        # Save the DB on disk (seconds changes)
@@ -76,5 +76,3 @@ Author Information
 ------------------
 
 Benno Joy
-
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MEMORY_DEFAULT = 512
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "redis"
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = MEMORY_DEFAULT
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = MEMORY_DEFAULT
+  end
+
+  config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "test.yml"
+  end
+end

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,14 +13,18 @@
   when: ansible_os_family == "RedHat" and ansible_distribution != "Fedora"
         and ansible_distribution_major_version == "7"
 
-- name: Install the Redis packages 
+- name: Install the Redis packages | Redhat
   yum: name={{ item }} state=present
-  with_items: redis_redhat_pkg
+  with_items:
+    - libselinux-python
+    - "{% if redis_server_version is defined %}redis={{ redis_server_version }}{% else %}redis{% endif %}"
   when: ansible_os_family == "RedHat"
 
-- name: Install the Redis packages 
+- name: Install the Redis packages | Debian
   apt: name={{ item }} state=present update_cache=yes
-  with_items: redis_ubuntu_pkg
+  with_items:
+    - python-selinux
+    - "{% if redis_server_version is defined %}redis-server={{ redis_server_version }}{% else %}redis-server{% endif %}"
   environment: env
   when: ansible_os_family == "Debian"
 

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  sudo: yes
+  roles:
+    - .

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,12 +3,3 @@
 env:
  RUNLEVEL: 1
 
-redis_redhat_pkg:
-  - libselinux-python
-  - redis
-
-redis_ubuntu_pkg:
-  - python-selinux
-  - redis-server
-
-  


### PR DESCRIPTION
[#98748824] Pin redis version

[Pin the versions of components that we use](https://www.pivotaltracker.com/story/show/98748824)

**What**

To prevent breaking changes of components (e.g. Tsuru API, MongoDB, etc) causing the platform to break we should pin or build to a particular version, this will ensure a consistent build.

This PR adds version control for [redis](http://redis.io/)

**How to review this PR**

This PR has been written to be reviewed in the following context:
- I want to create a vagrant environment to help me develop and test locally
- I want to parameterise one of the packages so I would like to move them into the `task/main.yml` file so I can specifically allow the `redis`  to be pinned to a specific version
- I want to remove the variables that I no longer use in `vars/main.yml` since I've moved them out into `task/main.yml'
- I want to update the documentation so others know how to pin a specific version of `redis`

**How to test this PR**

A vagrant box has been provided for testing.

```
$ vagrant up
```

You can supply the following snippet to the `site.yml` for testing version pinning:

```
vars:
  - redis_server_version: 2:2.8.4-2
```

**Who should review this PR**
- Anyone in the world, man, woman, child or meerkat!
