### PR TITLE
Change pidfile path in redis config

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -18,7 +18,7 @@ daemonize yes
 
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.
-pidfile /var/run/redis/redis.pid
+pidfile /var/run/redis/redis-server.pid
 
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.


### PR DESCRIPTION
# What

We have observed that redis doesn't restart. It actually fails silently when stopping, and again when starting. This is because the pidifle path is different in the redis config  than in the init script.

Upstream PR was raised: https://github.com/bennojoy/redis/pull/23
# How to review
- `vagrant up`
- `vagrant ssh`
- `ps aux|grep redis` check the pid
- `sudo /etc/init.d/redis-server restart`
- the pid should have changed
# Who can review

Anyone but @saliceti and @keymon 
